### PR TITLE
👷 Move image build stage to master executor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,14 +3,19 @@
 // https://github.com/feedhenry/fh-pipeline-library
 @Library('fh-pipeline-library') _
 
+final String COMPONENT = 'mysql'
+final String VERSION = '5.5'
+final String DOCKER_HUB_ORG = "rhmap"
+
+String BUILD = ""
+String DOCKER_HUB_REPO = ""
+String CHANGE_URL = ""
+
 fhBuildNode(['label': 'openshift']) {
 
-    final String COMPONENT = 'mysql'
-    final String VERSION = '5.5'
-    final String BUILD = env.BUILD_NUMBER
-    final String DOCKER_HUB_ORG = "rhmap"
-    final String DOCKER_HUB_REPO = COMPONENT
-    final String CHANGE_URL = env.CHANGE_URL
+    BUILD = env.BUILD_NUMBER
+    DOCKER_HUB_REPO = COMPONENT
+    CHANGE_URL = env.CHANGE_URL
 
     stage('Platform Update') {
         final Map updateParams = [
@@ -22,15 +27,25 @@ fhBuildNode(['label': 'openshift']) {
         fhCoreOpenshiftTemplatesComponentUpdate(updateParams)
     }
 
+    stash COMPONENT
+    archiveArtifacts writeBuildInfo('mysql-container', "${VERSION}-${BUILD}")
+}
+
+node('master') {
     stage('Build Image') {
+        unstash COMPONENT
+
         final Map params = [
                 fromDir: "./${VERSION}",
                 buildConfigName: COMPONENT,
                 imageRepoSecret: "dockerhub",
                 outputImage: "docker.io/${DOCKER_HUB_ORG}/${DOCKER_HUB_REPO}:${VERSION}-${BUILD}"
         ]
-        buildWithDockerStrategy params
-        archiveArtifacts writeBuildInfo('mysql-container', "${VERSION}-${BUILD}")
-    }
 
+        try {
+            buildWithDockerStrategy params
+        } finally {
+            sh "rm -rf *"
+        }
+    }
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-21735

This is to allow us to run builds in more constrained environments: we no longer need Jenkins master, and an agent pod, and a build running -- we just trigger the build from the master.